### PR TITLE
Allows to use a requestBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ with analyzers and mappings defined in elastic4s syntax or pass a
  ```
  which gives you a `parsingFailure` on creation if the string can't be parsed to json.
  
+ The `.from([source])` method requires you to give an `Indexable` for the elements to be indexed. Alternatively
+ you can use `.fromBuilder`, if you want to give an implicit `RequestBuilder`. This allows for more configuration
+ for the indexing, e.g. you can specify which `id` or which `timestamp` to use.
+ 
  #### Alias switching
  
  You can add the `.switchAliasFrom` step to the process of writing, if you want to switch an alias from

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,9 +1,9 @@
 import sbt._
 
 object Dependencies {
-  val elastic4sVersion = "5.2.7"
-  val circeVersion = "0.7.0"
-  private val akkaHttpVersion = "2.5.0"
+  val elastic4sVersion = "5.4.5"
+  val circeVersion = "0.8.0"
+  private val akkaVersion = "2.5.3"
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 
@@ -17,7 +17,7 @@ object Dependencies {
 
   lazy val elastic4sTestkit = "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion
 
-  lazy val akkaStream = "com.typesafe.akka" %% "akka-stream" % akkaHttpVersion
+  lazy val akkaStream = "com.typesafe.akka" %% "akka-stream" % akkaVersion
 
   lazy val cats =  "org.typelevel" %% "cats" % "0.9.0"
 

--- a/src/main/scala/com/yannick_cw/elastic_indexer4s/ElasticIndexer4s.scala
+++ b/src/main/scala/com/yannick_cw/elastic_indexer4s/ElasticIndexer4s.scala
@@ -8,26 +8,53 @@ import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import com.yannick_cw.elastic_indexer4s.elasticsearch.elasic_config.ElasticWriteConfig
 import com.sksamuel.elastic4s.Indexable
 import cats.instances.future.catsStdInstancesForFuture
+import com.sksamuel.elastic4s.streams.RequestBuilder
 import com.yannick_cw.elastic_indexer4s.elasticsearch.ElasticseachInterpreter
 import com.yannick_cw.elastic_indexer4s.indexing_logic.IndexableStream
+import com.sksamuel.elastic4s.ElasticDsl._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ElasticIndexer4s(esConf: ElasticWriteConfig)(implicit system: ActorSystem, materializer: ActorMaterializer, ex: ExecutionContext) {
-  def from[A](source: Source[A, NotUsed])(implicit indexable: Indexable[A]): IndexableStream[A, Future] =
-    new IndexableStream[A, Future](source, new ElasticseachInterpreter[A](esConf))(catsStdInstancesForFuture(ex))
+class ElasticIndexer4s(esConf: ElasticWriteConfig)(implicit system: ActorSystem,
+                                                   materializer: ActorMaterializer,
+                                                   ex: ExecutionContext) {
+
+  /**
+    * Creates a IndexableStream from a Source of elements and an Indexable for the element type
+    */
+  def from[Entity](source: Source[Entity, NotUsed])(
+      implicit indexable: Indexable[Entity]): IndexableStream[Entity, Future] = {
+    implicit val defaultBuilder: RequestBuilder[Entity] =
+      (entity: Entity) => indexInto(esConf.indexName / esConf.docType) source entity
+
+    new IndexableStream[Entity, Future](source, new ElasticseachInterpreter[Entity](esConf))(
+      catsStdInstancesForFuture(ex))
+  }
+
+  /**
+    * Creates a IndexableStream from a Source of elements and an requestBuilder for the element type
+    * This can be used for additional configuration on how to index elements
+    */
+  def fromBuilder[Entity](source: Source[Entity, NotUsed])(
+      implicit requestBuilder: RequestBuilder[Entity]): IndexableStream[Entity, Future] =
+    new IndexableStream[Entity, Future](source, new ElasticseachInterpreter[Entity](esConf))(
+      catsStdInstancesForFuture(ex))
 
   def withDecider(decider: Decider): ElasticIndexer4s = {
-    val materializer = ActorMaterializer(ActorMaterializerSettings(system).withSupervisionStrategy(decider))
+    val materializer = ActorMaterializer(
+      ActorMaterializerSettings(system).withSupervisionStrategy(decider))
     new ElasticIndexer4s(esConf)(system, materializer, ex)
   }
 }
 
 object ElasticIndexer4s {
-  def apply(esConf: ElasticWriteConfig, system: ActorSystem, materializer: ActorMaterializer, ex: ExecutionContext): ElasticIndexer4s =
+  def apply(esConf: ElasticWriteConfig,
+            system: ActorSystem,
+            materializer: ActorMaterializer,
+            ex: ExecutionContext): ElasticIndexer4s =
     new ElasticIndexer4s(esConf)(system, materializer, ex)
 
-  def apply(esConf: ElasticWriteConfig) = {
+  def apply(esConf: ElasticWriteConfig): ElasticIndexer4s = {
     implicit val system = ActorSystem()
     implicit val ex = system.dispatcher
     implicit val materializer = ActorMaterializer()

--- a/src/main/scala/com/yannick_cw/elastic_indexer4s/elasticsearch/ElasticWriter.scala
+++ b/src/main/scala/com/yannick_cw/elastic_indexer4s/elasticsearch/ElasticWriter.scala
@@ -2,27 +2,22 @@ package com.yannick_cw.elastic_indexer4s.elasticsearch
 
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.Sink
-import com.yannick_cw.elastic_indexer4s.Index_results.{IndexError, StageSucceeded, StageSuccess}
-import com.yannick_cw.elastic_indexer4s.elasticsearch.elasic_config.ElasticWriteConfig
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.Indexable
-import com.sksamuel.elastic4s.bulk.{BulkCompatibleDefinition, RichBulkItemResponse}
+import com.sksamuel.elastic4s.bulk.RichBulkItemResponse
 import com.sksamuel.elastic4s.streams.ReactiveElastic._
 import com.sksamuel.elastic4s.streams.{BulkIndexingSubscriber, RequestBuilder, ResponseListener}
+import com.yannick_cw.elastic_indexer4s.Index_results.{IndexError, StageSucceeded, StageSuccess}
+import com.yannick_cw.elastic_indexer4s.elasticsearch.elasic_config.ElasticWriteConfig
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Try
 import scala.util.control.NonFatal
 
 class ElasticWriter[A](
-  esConf: ElasticWriteConfig)(implicit system: ActorSystem, indexable: Indexable[A], ex: ExecutionContext) {
+  esConf: ElasticWriteConfig)(implicit system: ActorSystem, requestBuilder: RequestBuilder[A], ex: ExecutionContext) {
 
   import esConf._
-
-  private implicit val builder = new RequestBuilder[A] {
-    def request(post: A): BulkCompatibleDefinition =
-      indexInto(indexName / docType) source post
-  }
 
   //promise that is passed to the error and completion function of the elastic subscriber
   private val elasticFinishPromise: Promise[Unit] = Promise[Unit]()
@@ -70,6 +65,6 @@ class ElasticWriter[A](
 
 object ElasticWriter {
   def apply[A](esConf: ElasticWriteConfig)
-    (implicit system: ActorSystem, indexable: Indexable[A], ex: ExecutionContext): ElasticWriter[A] =
+    (implicit system: ActorSystem, requestBuilder: RequestBuilder[A], ex: ExecutionContext): ElasticWriter[A] =
     new ElasticWriter[A](esConf)
 }

--- a/src/main/scala/com/yannick_cw/elastic_indexer4s/elasticsearch/ElasticseachInterpreter.scala
+++ b/src/main/scala/com/yannick_cw/elastic_indexer4s/elasticsearch/ElasticseachInterpreter.scala
@@ -6,16 +6,23 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import cats.~>
 import com.yannick_cw.elastic_indexer4s.elasticsearch.elasic_config.ElasticWriteConfig
-import com.yannick_cw.elastic_indexer4s.elasticsearch.index_ops.{AliasSwitching, EsOpsClient, IndexDeletion}
+import com.yannick_cw.elastic_indexer4s.elasticsearch.index_ops.{
+  AliasSwitching,
+  EsOpsClient,
+  IndexDeletion
+}
 import com.yannick_cw.elastic_indexer4s.indexing_logic.FullStream
 import com.yannick_cw.elastic_indexer4s.indexing_logic.IndexLogic._
-import com.sksamuel.elastic4s.Indexable
+import com.sksamuel.elastic4s.streams.RequestBuilder
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ElasticseachInterpreter[Entity](esConf: ElasticWriteConfig)
-  (implicit ex: ExecutionContext, system: ActorSystem, materializer: ActorMaterializer, indexable: Indexable[Entity])
-  extends (IndexAction ~> Future) {
+class ElasticseachInterpreter[Entity](esConf: ElasticWriteConfig)(
+    implicit ex: ExecutionContext,
+    system: ActorSystem,
+    materializer: ActorMaterializer,
+    requestBuilder: RequestBuilder[Entity])
+    extends (IndexAction ~> Future) {
 
   private val writer = ElasticWriter[Entity](esConf)
   private val esOpsClient = EsOpsClient(esConf.client)
@@ -28,9 +35,11 @@ class ElasticseachInterpreter[Entity](esConf: ElasticWriteConfig)
       FullStream.run(source, writer.esSink, esConf.logWriteSpeedEvery)
 
     case SwitchAlias(minT, maxT, alias) =>
-      AliasSwitching(esOpsClient, minT, maxT, esConf.waitForElasticTimeout.toMillis).switchAlias(alias, esConf.indexName)
+      AliasSwitching(esOpsClient, minT, maxT, esConf.waitForElasticTimeout.toMillis)
+        .switchAlias(alias, esConf.indexName)
 
     case DeleteOldIndices(keep, aliasProtection) =>
-      IndexDeletion(esOpsClient).deleteOldest(esConf.indexPrefix, esConf.indexName, keep, aliasProtection)
+      IndexDeletion(esOpsClient)
+        .deleteOldest(esConf.indexPrefix, esConf.indexName, keep, aliasProtection)
   }
 }


### PR DESCRIPTION
## Instead of only allowing to specify the `Indexable` the user can now chose between `Indexable` and `RequestBuilder`

* allows more configuration for the user
* `fromBuilder` method takes `RequestBuilder`

* also updates versions